### PR TITLE
Free the allocated buffers in destroy()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -40,7 +40,7 @@ int	main(int argc, char **argv)
     printf("Performing self test...\n");
     if (self_test() != 0)
     {
-        failExit("Self test failed!\nEnsure svc/service access is patched,\nAnd that P9 crypto patches are installed.\n");
+        failExit("Self test failed!\nEnsure svc/service access is patched,\nAnd that P9 crypto patches are installed.\n\nIf you are sure this is the case, try again.");
     }
     
     printf("Self test succeeded!\n\n");

--- a/src/server.c
+++ b/src/server.c
@@ -120,6 +120,13 @@ void destroy()
 	gfxExit();
 	hidExit();
     psExit();
+    if (socket_buffer != NULL)
+    	free(socket_buffer);
+    socket_buffer = NULL;
+    
+    if (crypto_buffer != NULL)
+    	free(crypto_buffer);
+    crypto_buffer = NULL;
 }
 
 int manage_connection()


### PR DESCRIPTION
Failing to free the buffers means that at around the 25th auto recovery,
the ram runs out, and all further attempts at auto recovery WILL fail.
this fixes that.

Also,  if any outside forces changes keyY of the keyslot used for the test vector, it seems to cause the built in self test to fail,  but then it does succeed on the next attempt to recover.